### PR TITLE
fix pagination info in server mode

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -180,7 +180,7 @@
         />
       </div>
       <div class="pagination__items-index">
-        {{ `${firstIndexOfItemsInCurrentPage}-${lastIndexOfItemsInCurrentPage}` }}
+        {{ `${firstIndexOfItemsInCurrentPage}–${lastIndexOfItemsInCurrentPage}` }}
         of {{ totalItemsLength }}
       </div>
 
@@ -762,7 +762,9 @@ const totalItemsLength = computed((): number => (isServerSideMode.value ? props.
 
 const lastIndexOfItemsInCurrentPage = computed((): number => {
   if (isServerSideMode.value) {
-    return currentPaginationNumber.value * rowsPerPageReactive.value;
+    return Math.min(
+			totalItemsLength.value,
+			currentPaginationNumber.value * rowsPerPageReactive.value);
   }
   return Math.min(
     itemsFiltering.value.length,


### PR DESCRIPTION
### `Type`

> What types of changes does your code introduce?

I changed hypen to endash for the pagination display, which is the correct typography

In server mode, the last index of items was showing the amount for a full page, but often it's less than a full page, eg 12 items when page size is ten, you show 10-20 of 12, I expect to see 10-12 of 12. Maybe you didn't notice this because your doco page lists 500 items (no remainder when divided by page size) — if server mock items returned 497 items instead you will see the problem.

> Put an `x` in the boxes that apply_

- [x ] Fix
- [ ] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x ] Title as described
- [ ] Add unit test by vitest if necessary

not sure what that means, vitest, but I can't run anything locally doesn't work for some reason.