### PR TITLE
added updateSort emit and its type declaration

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -314,6 +314,7 @@ onMounted(() => {
 const emits = defineEmits([
   'clickRow',
   'expandRow',
+  'updateSort',
   'update:itemsSelected',
   'update:serverOptions',
 ]);
@@ -353,6 +354,7 @@ const {
   sortBy,
   sortType,
   updateServerOptionsSort,
+  emits
 );
 
 const {

--- a/src/hooks/useHeaders.ts
+++ b/src/hooks/useHeaders.ts
@@ -2,7 +2,9 @@ import {
   ref, Ref, computed, ComputedRef, WritableComputedRef,
 } from 'vue';
 import type { Header, SortType } from '../types/main';
-import type { ServerOptionsComputed, HeaderForRender, ClientSortOptions, EmitsEventName } from '../types/internal';
+import type {
+  ServerOptionsComputed, HeaderForRender, ClientSortOptions, EmitsEventName,
+} from '../types/internal';
 
 export default function useHeaders(
   checkboxColumnWidth: Ref<number>,
@@ -114,7 +116,10 @@ export default function useHeaders(
         sortDesc: newSortType === 'desc',
       };
     }
-    emits("updateSort", newSortType, newSortBy)
+    emits('updateSort', {
+      sortType: newSortType,
+      sortBy: newSortBy,
+    });
   };
 
   return {

--- a/src/hooks/useHeaders.ts
+++ b/src/hooks/useHeaders.ts
@@ -2,7 +2,7 @@ import {
   ref, Ref, computed, ComputedRef, WritableComputedRef,
 } from 'vue';
 import type { Header, SortType } from '../types/main';
-import type { ServerOptionsComputed, HeaderForRender, ClientSortOptions } from '../types/internal';
+import type { ServerOptionsComputed, HeaderForRender, ClientSortOptions, EmitsEventName } from '../types/internal';
 
 export default function useHeaders(
   checkboxColumnWidth: Ref<number>,
@@ -21,6 +21,7 @@ export default function useHeaders(
   sortBy: Ref<string>,
   sortType: Ref<SortType>,
   updateServerOptionsSort: (newSortBy: string, newSortType: SortType | null) => void,
+  emits: (event: EmitsEventName, ...args: any[]) => void,
 ) {
   const hasFixedColumnsFromUser = computed(() => headers.value.findIndex((header) => header.fixed) !== -1);
   const fixedHeadersFromUser = computed(() => {
@@ -113,6 +114,7 @@ export default function useHeaders(
         sortDesc: newSortType === 'desc',
       };
     }
+    emits("updateSort", newSortType, newSortBy)
   };
 
   return {

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -21,8 +21,8 @@
       :body-row-class-name="bodyRowClassNameFunction"
       :header-item-class-name="headerItemClassNameFunction"
       :body-item-class-name="bodyItemClassNameFunction"
-      must-sort
       @click-row="showItem"
+      @update-sort="updateSort"
     >
       <template #expand="item">
         <div style="padding: 15px">
@@ -88,7 +88,7 @@ import {
   computed, ref, reactive, toRefs,
 } from 'vue';
 import type {
-  Header, Item, FilterOption, ClickRowArgument, HeaderItemClassNameFunction, BodyItemClassNameFunction, BodyRowClassNameFunction,
+  Header, Item, FilterOption, ClickRowArgument, UpdateSortArgument, HeaderItemClassNameFunction, BodyItemClassNameFunction, BodyRowClassNameFunction,
 } from '../types/main';
 import DataTable from '../components/DataTable.vue';
 import { mockClientNestedItems, mockClientItems, mockDuplicateClientNestedItems } from '../mock';
@@ -135,6 +135,10 @@ const itemsSelected = ref<Item[]>([items.value[14]]);
 const showItem = (item: ClickRowArgument) => {
   console.log('item');
   console.log(JSON.stringify(item));
+};
+
+const updateSort = (sortOption: UpdateSortArgument) => {
+  console.log(sortOption);
 };
 // filtering
 

--- a/src/modes/ServerSide.vue
+++ b/src/modes/ServerSide.vue
@@ -24,6 +24,7 @@
       table-class-name="hc-table"
       theme-color="#1d90ff"
       border-cell
+      @update-sort="updateSort"
     >
       <template #address="{ address }">
         <a :href="address">{{ address }}</a>
@@ -84,7 +85,7 @@ import {
   defineComponent, ref, computed, watch, onMounted, Ref,
 } from 'vue';
 import {
-  Header, Item, ServerOptions, BodyItemClassNameFunction, BodyRowClassNameFunction, HeaderItemClassNameFunction,
+  Header, Item, ServerOptions, UpdateSortArgument, BodyItemClassNameFunction, BodyRowClassNameFunction, HeaderItemClassNameFunction,
 } from '../types/main';
 import DataTable from '../components/DataTable.vue';
 import { mockClientItems, mockServerItems } from '../mock';
@@ -159,6 +160,9 @@ export default defineComponent({
     const currentPageLastIndex = computed(() => dataTable.value?.currentPageLastIndex);
     const clientItemsLength = computed(() => dataTable.value?.clientItemsLength);
 
+    const updateSort = (sortOption: UpdateSortArgument) => {
+      console.log(sortOption);
+    };
     console.log('dataTable');
     console.log(dataTable.value);
 
@@ -201,6 +205,7 @@ export default defineComponent({
       prevPage,
       updatePage,
       bodyRowClassName,
+      updateSort,
     };
   },
 

--- a/src/types/internal.d.ts
+++ b/src/types/internal.d.ts
@@ -23,4 +23,4 @@ export type ClientSortOptions = {
 
 export type MultipleSelectStatus = 'allSelected' | 'noneSelected' | 'partSelected'
 
-export type EmitsEventName = 'clickRow' | 'expandRow' | 'update:itemsSelected' | 'update:serverOptions'
+export type EmitsEventName = 'clickRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions'

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -42,6 +42,11 @@ export type ClickRowArgument = Item & {
   indexInCurrentPage?: number
 }
 
+export type UpdateSortArgument = {
+  sortType: SortType | null
+  sortBy: string
+}
+
 export type HeaderItemClassNameFunction = (header: Header, index: number) => string
 export type BodyRowClassNameFunction = (item: Item, index: number) => string
 export type BodyItemClassNameFunction = (column: string, index: number) => string

--- a/types/main.d.ts
+++ b/types/main.d.ts
@@ -42,6 +42,11 @@ export type ClickRowArgument = Item & {
   indexInCurrentPage?: number
 }
 
+export type UpdateSortArgument = {
+  sortType: SortType | null
+  sortBy: string
+}
+
 export type HeaderItemClassNameFunction = (header: Header, index: number) => string
 export type BodyRowClassNameFunction = (item: Item, index: number) => string
 export type BodyItemClassNameFunction = (column: string, index: number) => string


### PR DESCRIPTION
### `Type`

> What types of changes does your code introduce?

I have added a new emit event called `updateSort` that gets triggered, when the type of 
sorting gets changed. It has the new type of sort and the name of the sorted column as parameters.

This is for example useful, if you have to re-render the content of an expanded row, whenever the sort changes.

> Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
