### PR TITLE
+ added body prepend and append slots

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -76,7 +76,7 @@
           </tr>
         </thead>
         <tbody
-          v-if="items.length && headerColumns.length"
+          v-if="headerColumns.length"
           class="vue3-easy-data-table__body"
           :class="{'row-alternation': alternating}"
         >

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -80,6 +80,9 @@
           class="vue3-easy-data-table__body"
           :class="{'row-alternation': alternating}"
         >
+          <slot 
+            name="body.prepend"
+          />
           <template
             v-for="(item, index) in pageItems"
             :key="index"
@@ -140,6 +143,9 @@
               </td>
             </tr>
           </template>
+          <slot 
+            name="body.append"
+          />
         </tbody>
       </table>
       <div

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -82,6 +82,18 @@
         >
           <slot 
             name="body.prepend"
+            v-bind="{
+              items = pageItems,
+              pagination = {
+                isFirstPage,
+                isLastPage,
+                currentPaginationNumber,
+                maxPaginationNumber,
+                nextPage,
+                prevPage
+              },
+              headers = headersForRender
+            }"
           />
           <template
             v-for="(item, index) in pageItems"
@@ -145,6 +157,18 @@
           </template>
           <slot 
             name="body.append"
+            v-bind="{
+              items = pageItems,
+              pagination = {
+                isFirstPage,
+                isLastPage,
+                currentPaginationNumber,
+                maxPaginationNumber,
+                nextPage,
+                prevPage
+              },
+              headers = headersForRender
+            }"
           />
         </tbody>
       </table>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -83,8 +83,8 @@
           <slot 
             name="body.prepend"
             v-bind="{
-              items = pageItems,
-              pagination = {
+              items: pageItems,
+              pagination: {
                 isFirstPage,
                 isLastPage,
                 currentPaginationNumber,
@@ -92,7 +92,7 @@
                 nextPage,
                 prevPage
               },
-              headers = headersForRender
+              headers: headersForRender
             }"
           />
           <template
@@ -158,8 +158,8 @@
           <slot 
             name="body.append"
             v-bind="{
-              items = pageItems,
-              pagination = {
+              items: pageItems,
+              pagination: {
                 isFirstPage,
                 isLastPage,
                 currentPaginationNumber,
@@ -167,7 +167,7 @@
                 nextPage,
                 prevPage
               },
-              headers = headersForRender
+              headers: headersForRender
             }"
           />
         </tbody>

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -34,6 +34,17 @@
       @click-row="showItem"
       @update-sort="updateSort"
     >
+      <template #body.prepend="body">
+        <tr>
+          <td
+            v-for="(header, index) in body.headers"
+            :key="index"
+          >
+            <span v-if="isDataHeader(header)">Coloumn {{ header.text }}</span>
+          </td>
+        </tr>
+      </template>
+
       <template #expand="item">
         <div style="padding: 15px">
           {{ item.name }} won championships
@@ -56,6 +67,10 @@
             <input v-model="nameCriteria">
           </div>
         </div>
+      </template>
+
+       <template #body.append>
+        <span>body.append</span>
       </template>
     </DataTable>
 
@@ -208,6 +223,9 @@ const prevPage = () => {
 const updatePage = (paginationNumber: number) => {
   dataTable.value.updatePage(paginationNumber);
 };
+const isDataHeader = (header: Header) => {
+  return !(header.value === 'checkbox' || header.value === 'index' || header.value === 'expand')
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
### `Type`

> What types of changes does your code introduce?

Added prepend and append slots to the table body similar to how [vuetifiyjs v2](https://vuetifyjs.com/en/api/v-data-table/#slots-body.prepend) is doing it

These slots represent the first and last row of the visible table and are always present (even if no data is available).
That space might be used to implement a per column search or whole column copies.

> Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
