### PR TITLE
Fixed header value to lower case in header-name for slot

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -56,8 +56,8 @@
                 :class="`direction-${headerTextDirection}`"
               >
                 <slot
-                  v-if="slots[`header-${header.value}`]"
-                  :name="`header-${header.value}`"
+                  v-if="slots[`header-${header.value.toLowerCase()}`]"
+                  :name="`header-${header.value.toLowerCase()}`"
                   v-bind="header"
                 />
                 <span

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -56,7 +56,12 @@
                 :class="`direction-${headerTextDirection}`"
               >
                 <slot
-                  v-if="slots[`header-${header.value.toLowerCase()}`]"
+                  v-if="slots[`header-${header.value}`]"
+                  :name="`header-${header.value}`"
+                  v-bind="header"
+                />
+                <slot
+                  v-else-if="slots[`header-${header.value.toLowerCase()}`]"
                   :name="`header-${header.value.toLowerCase()}`"
                   v-bind="header"
                 />


### PR DESCRIPTION
I am using your code, thank you for making good code.
I find a bug in this project and request a fix.

### `Type`

> What types of changes does your code introduce?
- `#header-{name}` - If the name contains uppercase letters, it is not applied.
  - For example, `createTime` and `userType` do not apply. 
- https://hc200ok.github.io/vue3-easy-data-table-doc/features/header-slot.html

> Put an `x` in the boxes that apply_

- [X] Fix
- [x] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [X] Title as described
- [x] Add unit test by vitest if necessary
