### PR TITLE
Add $event to @click-row emit (PR for #220)

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -120,10 +120,10 @@
               :class="[{'even-row': (index + 1) % 2 === 0},
                        typeof bodyRowClassName === 'string' ? bodyRowClassName : bodyRowClassName(item, index + 1)]"
               @click="($event) => {
-                clickRow(item, 'single');
+                clickRow(item, 'single', $event);
                 clickRowToExpand && updateExpandingItemIndexList(index + prevPageEndIndex, item, $event);
               }"
-              @dblclick="clickRow(item, 'double')"
+              @dblclick="($event) => clickRow(item, 'double', $event)"
             >
               <td
                 v-for="(column, i) in headerColumns"

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -123,7 +123,7 @@
                 clickRow(item, 'single', $event);
                 clickRowToExpand && updateExpandingItemIndexList(index + prevPageEndIndex, item, $event);
               }"
-              @dblclick="($event) => clickRow(item, 'double', $event)"
+              @dblclick="($event) => {clickRow(item, 'double', $event)}"
             >
               <td
                 v-for="(column, i) in headerColumns"

--- a/src/hooks/useClickRow.ts
+++ b/src/hooks/useClickRow.ts
@@ -8,7 +8,7 @@ export default function useClickRow(
   showIndex: Ref<boolean>,
   emits: (event: EmitsEventName, ...args: any[]) => void,
 ) {
-  const clickRow = (item: Item, clickType: ClickEventType) => {
+  const clickRow = (item: Item, clickType: ClickEventType, $event: Event) => {
     if (clickEventType.value !== clickType) return;
 
     const clickRowArgument = { ...item };
@@ -22,7 +22,7 @@ export default function useClickRow(
       delete clickRowArgument.index;
       clickRowArgument.indexInCurrentPage = index;
     }
-    emits('clickRow', clickRowArgument);
+    emits('clickRow', clickRowArgument, $event);
   };
 
   return {


### PR DESCRIPTION
Emits the $event on @click-row. See #220 

Usage sample:

```
<script setup lang="ts">
import { ClickRowArgument } from 'vue3-easy-data-table';

const handleClickRow = (item: ClickRowArgument, $event: Event) => {
  console.log($event.detail);
}
<script>

<template>
  <easy-data-table @click-row="handleClickRow" .../>
</template>
```


