### PR TITLE
Add comparsion option "in" for arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.31",
+  "version": "1.5.32",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/src/hooks/useTotalItems.ts
+++ b/src/hooks/useTotalItems.ts
@@ -64,6 +64,8 @@ export default function useTotalItems(
               return itemValue >= criteria;
             case 'between':
               return itemValue >= Math.min(...criteria) && itemValue <= Math.max(...criteria);
+            case 'in':
+              return criteria.includes(itemValue);
             default:
               return itemValue === criteria;
           }

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -199,9 +199,8 @@ const filterOptions = computed((): FilterOption[] => {
   const filterOptionsArray: FilterOption[] = [];
   filterOptionsArray.push({
     field: 'name',
-    criteria: nameCriteria.value,
-    comparison: (value, criteria): boolean => (value != null
-      && value.includes(criteria)),
+    criteria: ['name-1', 'name-2'],
+    comparison: 'in',
   });
   return filterOptionsArray;
 });

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -1,6 +1,6 @@
 export type SortType = 'asc' | 'desc'
 
-export type FilterComparison = '=' | '!=' | '>' | '>=' | '<' | '<=' | 'between';
+export type FilterComparison = '=' | '!=' | '>' | '>=' | '<' | '<=' | 'between' | 'in';
 
 export type Item = Record<string, any>
 

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -18,6 +18,10 @@ export type FilterOption = {
   criteria: number
 } | {
   field: string
+  comparison: 'in'
+  criteria: number[] | string[]
+}| {
+  field: string
   comparison: (value: any, criteria: string) => boolean
   criteria: string
 }


### PR DESCRIPTION
Add an option for filter options to work with arrays as criteria with `in` comparison. 

Sample usage:

```
const filterOptions = computed(():FilterOption[] => {
  const filterOptionsArray: FilterOption[] = [];
  
  filterOptionsArray.push({
    field: 'age',
    comparison: 'in',
    criteria: [42, 43, 44], // Usually a reactive obj
  });

  return filterOptionsArray;
});
```