### PR TITLE
Add a contextmenu (right click) emit

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -129,6 +129,7 @@
                 clickRowToExpand && updateExpandingItemIndexList(index + prevPageEndIndex, item, $event);
               }"
               @dblclick="($event) => {clickRow(item, 'double', $event)}"
+              @contextmenu.prevent="($event) => {emits('contextmenuRow', item, $event)}"
             >
               <td
                 v-for="(column, i) in headerColumns"
@@ -390,6 +391,7 @@ onMounted(() => {
 
 const emits = defineEmits([
   'clickRow',
+  'contextmenuRow',
   'selectRow',
   'deselectRow',
   'expandRow',


### PR DESCRIPTION
Add a simple right click (contextmenu) handler. (As only left and left double click events are emitted currently with the row item). 

This allows an easy integration of a contextmenu.

```vue
<script lang="ts" setup>
const handleContextmenu = (item: Item, event: Event) => {
  console.log('do something', item);
}
</script>

<template>
  <easy-data-table @contextmenu-row="handleContextmenu" ...>
  </easy-data-table>
</template>
```