### PR TITLE
Add an optional "header-static" slot to replace the DataTable's heade…

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.34",
+  "version": "1.5.35",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -24,7 +24,10 @@
             :style="getColStyle(header)"
           />
         </colgroup>
-        <slot v-if="slots['customize-header']" name="customize-header"/>
+        <slot
+          v-if="slots['customize-header']"
+          name="customize-header"
+        />
         <thead
           v-else-if="headersForRender.length && !hideHeader"
           class="vue3-easy-data-table__header"

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -46,6 +46,25 @@
       @update-total-items="updateTotalItems"
       show-index-symbol="$"
     >
+     <template #customize-header>
+        <thead class="my-static-header">
+          <tr>
+            <th colspan="3" rowspan="2"></th>
+            <th colspan="4">member info</th>
+            <th colspan="4">indicator</th>
+          </tr>
+          <tr>
+            <th>name</th>
+            <th>team</th>
+            <th>number</th>
+            <th>position</th>
+            <th>height</th>
+            <th>weight</th>
+            <th>lastAttended</th>
+            <th>country</th>
+          </tr>
+        </thead>
+      </template>
       <template #expand="item">
         <div style="padding: 15px">
           {{ item.name }} won championships
@@ -341,6 +360,12 @@ const updateRowsPerPageSelect = (e: Event) => {
   --easy-table-scrollbar-thumb-color: #2d3a4f;
 
   --easy-table-loading-mask-background-color: #2d3a4f;
+}
+
+.my-static-header th {
+  color: white;
+  border-right: 1px solid #445269;
+  border-bottom: 1px solid #445269;
 }
 
 </style>


### PR DESCRIPTION
…r with static thead tag content.

### `Type`

- [ ] Fix
- [x] Feature


### `Checklist`

- [x] Title as described
- [ ] Add unit test by vitest if necessary

### `Details`

I use vue3-easy-data-table conveniently. Thanks for making it public.

I'm currently using Vue3 to create a table with a complex structured header containing `colspan` etc. Luckily this header is static, so let me suggest adding a `header-static` slot feature that simply replaces the DataTable's header.

As a child element of DataTable, a typical usage would be:
```:html
<template #header-static>
   <thead>
     <tr><th colspan="3">A big label</th></tr>
     <tr><th>A</th><th>B</th><th>C</th></tr>
   </thead>
</template>
```
p.s. I'd also like to suggest `header-prepend` and `header-append` slot to coexist with existing headers, but that's for another time.