### PR TITLE
Replace '-1' with 'All' in RowsItems Dropdown

### DIFF
--- a/src/components/RowsSelector.vue
+++ b/src/components/RowsSelector.vue
@@ -21,7 +21,7 @@
         :class="{selected: item === rowsComputed }"
         @click="changeSelectedRows(item)"
       >
-        {{ item }}
+        {{ item === "-1" ? 'All' : item }}
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Negative 1 is usually used as all Pages option in different apps, (Vuetify DataTable also does that)`:rows-items=[10,20,50,-1]` will label `-1` option as `All`

```
|  -- v |
|   10  |
|   20  |
|   All |
```

### `Type`

> What types of changes does your code introduce?

> Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
