### PR TITLE
Change tableHeight conversion expression and type

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -367,7 +367,7 @@ const {
 } = toRefs(props);
 
 // style related computed variables
-const tableHeightPx = computed(() => (tableHeight.value ? `${tableHeight.value}px` : null));
+const tableHeightPx = computed(() => (tableHeight.value ? (isFinite(tableHeight.value) ? `${tableHeight.value}px` : tableHeight.value) : null));
 const tableMinHeightPx = computed(() => `${tableMinHeight.value}px`);
 
 // global style related variable

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -132,7 +132,7 @@ export default {
     default: 180,
   },
   tableHeight: {
-    type: Number,
+    type: [Number, String],
     default: null,
   },
   themeColor: {


### PR DESCRIPTION
### `Type`

> What types of changes does your code introduce?  

Allow setting of strings so that "calc()" or similar can be used to make the table height follow the window height.  
Example: table-height="calc(100vh - 150px)"  

> Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
