### PR TITLE
Force Pagination Buttons to re-render when server options are changed

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -278,7 +278,7 @@
           #buttonsPagination
         >
           <ButtonsPagination
-            :key="JSON.stringify(serverOptionsComputed)"
+            :key="JSON.stringify({...serverOptionsComputed, ...currentPaginationNumber})"
             :current-pagination-number="currentPaginationNumber"
             :max-pagination-number="maxPaginationNumber"
             @update-page="updatePage"

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -278,6 +278,7 @@
           #buttonsPagination
         >
           <ButtonsPagination
+            :key="JSON.stringify(serverOptionsComputed)"
             :current-pagination-number="currentPaginationNumber"
             :max-pagination-number="maxPaginationNumber"
             @update-page="updatePage"


### PR DESCRIPTION
### `Type`

> What types of changes does your code introduce?
When use ButtonsPagination prop, the buttons Component, doesn't get updated when using serverOptions. Suggested way is to re-render the whole DataTable but it can only be solved by using `:key` attribute on `ButtonsPagination` component

It also closed #232 

> Put an `x` in the boxes that apply_

- [x] Fix
- [ ] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
