### PR TITLE
Add 'itemsKey' prop and items-expanded v-model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-easy-data-table",
-  "version": "1.5.16",
+  "version": "1.5.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-easy-data-table",
-      "version": "1.5.16",
+      "version": "1.5.44",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.2.45"
@@ -24,7 +24,7 @@
         "happy-dom": "^5.0.0",
         "sass": "^1.51.0",
         "typescript": "^4.5.4",
-        "vite": "^2.9.9",
+        "vite": "^2.9.16",
         "vitest": "^0.13.1",
         "vue-eslint-parser": "^9.0.1",
         "vue-tsc": "^0.34.7"
@@ -2223,9 +2223,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -3317,15 +3317,15 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5203,9 +5203,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -5990,16 +5990,16 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.9.tgz",
-      "integrity": "sha512-ffaam+NgHfbEmfw/Vuh6BHKKlI/XIAhxE5QSS7gFLIngxg171mg1P3a4LSRME0z2ZU1ScxoKzphkipcYwSD5Ew==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
-        "rollup": "^2.59.0"
+        "rollup": ">=2.59.0 <2.78.0"
       }
     },
     "vitest": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.44",
+  "version": "1.5.45",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.45",
+  "version": "1.5.47",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "happy-dom": "^5.0.0",
     "sass": "^1.51.0",
     "typescript": "^4.5.4",
-    "vite": "^2.9.9",
+    "vite": "^2.9.16",
     "vitest": "^0.13.1",
     "vue-eslint-parser": "^9.0.1",
     "vue-tsc": "^0.34.7"

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -369,6 +369,8 @@ const {
   themeColor,
   rowsOfPageSeparatorMessage,
   showIndexSymbol,
+  itemsExpanded,
+  itemsKey,
   preventContextMenuRow
 } = toRefs(props);
 
@@ -411,7 +413,8 @@ const emits = defineEmits([
   'update:serverOptions',
   'updatePageItems',
   'updateTotalItems',
-  'selectAll'
+  'selectAll',
+  'update:itemsExpanded',
 ]);
 
 const isMultipleSelectable = computed((): boolean => itemsSelected.value !== null);
@@ -485,6 +488,7 @@ const {
   serverItemsLength,
   multiSort,
   emits,
+  itemsKey,
 );
 
 const {
@@ -521,6 +525,7 @@ const {
   showIndex,
   totalItems,
   totalItemsLength,
+  itemsKey,
 );
 
 const prevPageEndIndex = computed(() => {
@@ -536,6 +541,8 @@ const {
   pageItems,
   prevPageEndIndex,
   emits,
+  itemsExpanded,
+  itemsKey,
 );
 
 const {

--- a/src/hooks/useExpandableRow.ts
+++ b/src/hooks/useExpandableRow.ts
@@ -1,11 +1,14 @@
-import { ref, Ref, ComputedRef } from 'vue';
-import type { Item } from '../types/main';
+import { ref, Ref, ComputedRef, watchEffect } from 'vue';
+import type { Item, ItemKey } from '../types/main';
 import type { EmitsEventName } from '../types/internal';
+import { getItemIndex } from '../utils';
 
 export default function useExpandableRow(
   items: Ref<Item[]>,
   prevPageEndIndex: ComputedRef<number>,
   emits: (event: EmitsEventName, ...args: any[]) => void,
+  itemsExpanded: Ref<Item[]>,
+  itemsKey: Ref<ItemKey>
 ) {
   const expandingItemIndexList = ref<number[]>([]);
 
@@ -14,16 +17,34 @@ export default function useExpandableRow(
     const index = expandingItemIndexList.value.indexOf(expandingItemIndex);
     if (index !== -1) {
       expandingItemIndexList.value.splice(index, 1);
+      emitItemsExpanded();
     } else {
-      const currentPageExpandIndex = items.value.findIndex((item) => JSON.stringify(item) === JSON.stringify(expandingItem));
+      const currentPageExpandIndex = getItemIndex(items.value, expandingItem, itemsKey.value)
       emits('expandRow', prevPageEndIndex.value + currentPageExpandIndex, expandingItem);
       expandingItemIndexList.value.push(prevPageEndIndex.value + currentPageExpandIndex);
+      emitItemsExpanded();
     }
   };
 
   const clearExpandingItemIndexList = () => {
     expandingItemIndexList.value = [];
   };
+
+  watchEffect(() => {
+    const indexList = itemsExpanded.value.reduce<number[]>((itemsExpandedIndex, expandedItem) => {
+      const index = getItemIndex(items.value, expandedItem, itemsKey.value)
+      if (index !== -1) {
+        itemsExpandedIndex.push(index + prevPageEndIndex.value)
+      }
+      return itemsExpandedIndex
+    }, [])
+    expandingItemIndexList.value = indexList
+  })
+
+
+  function emitItemsExpanded() {
+    emits('update:itemsExpanded', expandingItemIndexList.value.map(index => items.value[index - prevPageEndIndex.value]))
+  }
 
   return {
     expandingItemIndexList,

--- a/src/hooks/useTotalItems.ts
+++ b/src/hooks/useTotalItems.ts
@@ -1,9 +1,9 @@
 import {
   Ref, computed, ComputedRef, watch,
 } from 'vue';
-import type { Item, FilterOption } from '../types/main';
+import type { Item, FilterOption, ItemKey } from '../types/main';
 import type { ClientSortOptions, EmitsEventName } from '../types/internal';
-import { getItemValue } from '../utils';
+import { areItemsEqual, getItemValue } from '../utils';
 
 export default function useTotalItems(
   clientSortOptions: Ref<ClientSortOptions | null>,
@@ -16,6 +16,7 @@ export default function useTotalItems(
   serverItemsLength: Ref<number>,
   multiSort: Ref<boolean>,
   emits: (event: EmitsEventName, ...args: any[]) => void,
+  itemsKey: Ref<ItemKey>
 ) {
   const generateSearchingTarget = (item: Item): string => {
     if (typeof searchField.value === 'string' && searchField.value !== '') return getItemValue(searchField.value, item);
@@ -152,8 +153,8 @@ export default function useTotalItems(
       selectItemsComputed.value = selectItemsArr;
       emits('selectRow', item);
     } else {
-      selectItemsComputed.value = selectItemsComputed.value.filter((selectedItem) => JSON.stringify(selectedItem)
-        !== JSON.stringify(item));
+      selectItemsComputed.value = selectItemsComputed.value
+        .filter((selectedItem) => !areItemsEqual(selectedItem, item, itemsKey.value));
       emits('deselectRow', item);
     }
   };

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -9,6 +9,7 @@
   <span>search value: </span>
   <input type="text" v-model="searchValue">
   <div>
+    <button @click="refresh">Refresh</button>
     <DataTable
       table-node-id="my-table"
       v-model:items-selected="itemsSelected"
@@ -44,6 +45,8 @@
       @update-page-items="updateItems"
       @update-total-items="updateTotalItems"
       show-index-symbol="$"
+      items-key="id"
+      v-model:items-expanded="expandedItems"
     >
      <!-- <template #customize-headers>
         <thead class="my-static-header">
@@ -138,6 +141,7 @@ const switchToNested = () => {
   items.value = mockClientNestedItems(100);
 };
 const headers: Header[] = [
+  { text: "ID", value: "id" },
   { text: "Name", value: "name" },
   { text: "TEAM", value: "team"},
   { text: "NUMBER", value: "number", sortable: true},
@@ -146,6 +150,7 @@ const headers: Header[] = [
   { text: "WEIGHT (lbs)", value: "indicator.weight", sortable: true},
   { text: "LAST ATTENDED", value: "lastAttended", width: 200},
   { text: "COUNTRY", value: "country"},
+  { text: "LAST UPDATE", value: "updated"},
 ];
 
 // const headers: Header[] = headersMocked;
@@ -164,24 +169,31 @@ const updateTotalItems = (items: Item[]) => {
   console.log('total items');
   console.log(JSON.stringify(items));
 };
+const initialItems = [
+  { id: '1', name: "Stephen Curry", firstName: "GSW", number: 30, position: 'G', indicator: {"height": '6-2', "weight": 185}, lastAttended: "Davidson", country: "USA"},
+  { id: '2', name: "Kevin Durant", firstName: "BKN", number: 7, position: 'F', indicator: {"height": '6-10', "weight": 240}, lastAttended: "Texas-Austin", country: "USA"},
+  { id: '3', name: "Lebron James", firstName: "LAL", number: 7, position: 'F', indicator: {"height": '6-9', "weight": 185}, lastAttended: "St. Vincent-St. Mary HS (OH)", country: "USA"},
+  { id: '4', name: "Giannis Antetokounmpo", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 242}, lastAttended: "Filathlitikos", country: "Greece"},
+  { id: '5', name: "HC", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 243}, lastAttended: "Filathlitikos", country: "Greece"},
+  { id: '6', name: "Stephen Curry", firstName: "GSW", number: 30, position: 'G', indicator: {"height": '6-2', "weight": 185}, lastAttended: "Davidson", country: "USA"},
+  { id: '7', name: "Kevin Durant", firstName: "BKN", number: 7, position: 'F', indicator: {"height": '6-10', "weight": 240}, lastAttended: "Texas-Austin", country: "USA"},
+  { id: '8', name: "Lebron James", firstName: "LAL", number: 7, position: 'F', indicator: {"height": '6-9', "weight": 185}, lastAttended: "St. Vincent-St. Mary HS (OH)", country: "USA"},
+  { id: '9', name: "Giannis Antetokounmpo", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 242}, lastAttended: "Filathlitikos", country: "Greece"},
+  { id: '10', name: "HC", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 243}, lastAttended: "Filathlitikos", country: "Greece"},
+  { id: '11', name: "Stephen Curry", firstName: "GSW", number: 30, position: 'G', indicator: {"height": '6-2', "weight": 185}, lastAttended: "Davidson", country: "USA"},
+  { id: '12', name: "Kevin Durant", firstName: "BKN", number: 7, position: 'F', indicator: {"height": '6-10', "weight": 240}, lastAttended: "Texas-Austin", country: "USA"},
+  { id: '13', name: "Lebron James", firstName: "LAL", number: 7, position: 'F', indicator: {"height": '6-9', "weight": 185}, lastAttended: "St. Vincent-St. Mary HS (OH)", country: "USA"},
+  { id: '14', name: "Giannis Antetokounmpo", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 242}, lastAttended: "Filathlitikos", country: "Greece"},
+  { id: '15', name: "HC", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 243}, lastAttended: "Filathlitikos", country: "Greece"},
+]
+function getItems() {
+  return initialItems.map(item => ({...item, updated: new Date() }))
+}
+const items = ref<Item[]>(getItems());
+async function refresh() {
+  items.value = getItems()
+}
 
-const items = ref<Item[]>([
-  { name: "Stephen Curry", firstName: "GSW", number: 30, position: 'G', indicator: {"height": '6-2', "weight": 185}, lastAttended: "Davidson", country: "USA"},
-  { name: "Kevin Durant", firstName: "BKN", number: 7, position: 'F', indicator: {"height": '6-10', "weight": 240}, lastAttended: "Texas-Austin", country: "USA"},
-  { name: "Lebron James", firstName: "LAL", number: 7, position: 'F', indicator: {"height": '6-9', "weight": 185}, lastAttended: "St. Vincent-St. Mary HS (OH)", country: "USA"},
-  { name: "Giannis Antetokounmpo", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 242}, lastAttended: "Filathlitikos", country: "Greece"},
-  { name: "HC", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 243}, lastAttended: "Filathlitikos", country: "Greece"},
-  { name: "Stephen Curry", firstName: "GSW", number: 30, position: 'G', indicator: {"height": '6-2', "weight": 185}, lastAttended: "Davidson", country: "USA"},
-  { name: "Kevin Durant", firstName: "BKN", number: 7, position: 'F', indicator: {"height": '6-10', "weight": 240}, lastAttended: "Texas-Austin", country: "USA"},
-  { name: "Lebron James", firstName: "LAL", number: 7, position: 'F', indicator: {"height": '6-9', "weight": 185}, lastAttended: "St. Vincent-St. Mary HS (OH)", country: "USA"},
-  { name: "Giannis Antetokounmpo", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 242}, lastAttended: "Filathlitikos", country: "Greece"},
-  { name: "HC", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 243}, lastAttended: "Filathlitikos", country: "Greece"},
-  { name: "Stephen Curry", firstName: "GSW", number: 30, position: 'G', indicator: {"height": '6-2', "weight": 185}, lastAttended: "Davidson", country: "USA"},
-  { name: "Kevin Durant", firstName: "BKN", number: 7, position: 'F', indicator: {"height": '6-10', "weight": 240}, lastAttended: "Texas-Austin", country: "USA"},
-  { name: "Lebron James", firstName: "LAL", number: 7, position: 'F', indicator: {"height": '6-9', "weight": 185}, lastAttended: "St. Vincent-St. Mary HS (OH)", country: "USA"},
-  { name: "Giannis Antetokounmpo", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 242}, lastAttended: "Filathlitikos", country: "Greece"},
-  { name: "HC", firstName: "MIL", number: 34, position: 'F', indicator: {"height": '6-11', "weight": 243}, lastAttended: "Filathlitikos", country: "Greece"},
-]);
 
 // const items = ref<Item[]>(mockClientItems());
 
@@ -196,6 +208,7 @@ const items = ref<Item[]>([
 // ];
 
 const itemsSelected = ref<Item[]>([items.value[1]]);
+const expandedItems = ref<Item[]>([items.value[1]]);
 
 const showItem = (item: ClickRowArgument) => {
   console.log('item 111');

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -3,6 +3,7 @@ import type {
   SortType, Item, ServerOptions, FilterOption,
   HeaderItemClassNameFunction, BodyItemClassNameFunction, BodyRowClassNameFunction,
   TextDirection,
+  ItemKeyFn,
 } from './types/main';
 import type { ClickEventType } from './types/internal';
 
@@ -195,8 +196,20 @@ export default {
     type: String,
     default: '#',
   },
+  itemsExpanded: {
+    type: Array as PropType<Item[]>,
+    default: [],
+  },
+  /** String object key('id' it's the most common)
+   * or Function that returns a unique value for a row.
+   * It improves the tracking of expanded and checked rows.
+  */
+  itemsKey: {
+    type: [Function as PropType<ItemKeyFn>, String],
+    default: undefined,
+  },
   preventContextMenuRow: {
     type: Boolean,
     default: true
-  }
+  },
 };

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -81,7 +81,7 @@ export default {
   },
   loading: {
     type: Boolean,
-    deault: false,
+    default: false,
   },
   rowsPerPage: {
     type: Number,

--- a/src/types/internal.d.ts
+++ b/src/types/internal.d.ts
@@ -26,4 +26,4 @@ export type ClickEventType = 'single' | 'double'
 export type MultipleSelectStatus = 'allSelected' | 'noneSelected' | 'partSelected'
 
 // eslint-disable-next-line max-len
-export type EmitsEventName = 'clickRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll'
+export type EmitsEventName = 'clickRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll' | 'update:itemsExpanded'

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -56,3 +56,6 @@ export type BodyRowClassNameFunction = (item: Item, rowNumber: number) => string
 export type BodyItemClassNameFunction = (column: string, rowNumber: number) => string
 
 export type TextDirection = 'center' | 'left' | 'right'
+
+export type ItemKeyFn = (item: Item) => string | number
+export type ItemKey = ItemKeyFn | string | undefined

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { Item } from './types/main';
+import type { Item, ItemKey } from './types/main';
 
 export function getItemValue(column: string, item: Item) {
   if (column.includes('.')) {
@@ -27,4 +27,25 @@ export function getItemValue(column: string, item: Item) {
 export function generateColumnContent(column: string, item: Item) {
   const content = getItemValue(column, item);
   return Array.isArray(content) ? content.join(',') : content;
+}
+
+function getComparatorFn(itemToCompare: Item, key: ItemKey) {
+ let comparatorFunction = (item: Item) => JSON.stringify(item) === JSON.stringify(itemToCompare)
+    
+    if (key && typeof key === 'function') {
+      comparatorFunction = (item: Item) => key(item) === key(itemToCompare)
+    }
+    if (key && typeof key === 'string') {
+      comparatorFunction = (item: Item) => getItemValue(key, item) === getItemValue(key, itemToCompare)
+    }
+    return comparatorFunction
+} 
+
+export function getItemIndex(allItems: Item[], item: Item, key: ItemKey) {
+  return allItems.findIndex(getComparatorFn(item, key));
+}
+
+export function areItemsEqual(item: Item, itemToCompare: Item, key: ItemKey) {
+ const areEqualsFn = getComparatorFn(item, key)
+  return areEqualsFn(itemToCompare);
 }

--- a/test/DataTable.spec.js
+++ b/test/DataTable.spec.js
@@ -219,3 +219,54 @@ describe('Server side paginate and sort', () => {
     }]);
   });
 });
+
+describe('Row Tracking', () => {
+  it('should select the first item',  async () => {
+    // Arrange
+    const rowsPerPage = 2
+    const mockItems = mockClientItems(rowsPerPage);
+    const firstItem = {...mockItems[0], address: 'New ADDRESS !@#!'}
+    const wrapper = mount(DataTable, {
+      props: {
+        itemsSelected: [firstItem],
+        items: mockItems,
+        headers: headersMocked,
+        rowsPerPage,
+        itemsKey: 'name'
+      },
+    });
+    
+    // Act
+    let checkboxes = wrapper.findAll('.easy-checkbox input');
+
+    // Assert
+    expect(checkboxes).toHaveLength(rowsPerPage + 1)
+    const checkedList = checkboxes.map(checkbox => checkbox.element.checked)
+    expect(checkedList).toEqual([false, true, false]);
+  })
+
+  it('should expand the first item',  async () => {
+    // Arrange
+    const rowsPerPage = 2
+    const mockItems = mockClientItems(rowsPerPage);
+    const firstItem = {...mockItems[0], address: 'New ADDRESS !@#!'}
+    const wrapper = mount(DataTable, {
+      props: {
+        itemsExpanded: [firstItem],
+        items: mockItems,
+        headers: headersMocked,
+        rowsPerPage,
+        itemsKey: 'name',
+      },
+      slots: {
+        expand: `<template #expand="item"> Hello expanded row </template>`
+      } 
+    });
+
+    // Act
+    let expandedIcons = wrapper.findAll('.expand-icon.expanding');
+
+    // Assert
+    expect(expandedIcons).toHaveLength(1)
+  })
+})

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { areItemsEqual, getItemIndex } from '../src/utils';
+
+interface User {
+  id: string;
+  name: string;
+  lastName: string;
+}
+
+describe('Utils functions', () => {
+  describe('areItemsEqual()', () => {
+    it('should return true using the object key', () => {
+      const leftItem: User = { id: '1', name: 'John', lastName: 'Doe' };
+      const rightItem: User = { id: '1', name: 'John', lastName: 'Does' };
+      expect(areItemsEqual(leftItem, rightItem, 'id')).toBe(true);
+    });
+
+    it('should return true using the function key', () => {
+      const leftItem: User = { id: '1', name: 'John', lastName: 'Doe' };
+      const rightItem: User = { id: '2', name: 'John', lastName: 'Doe' };
+      const keyFn = (item: User) => item.name + item.lastName;
+      expect(areItemsEqual(leftItem, rightItem, keyFn as any)).toBe(true);
+    });
+
+    it('should return true using an undefined key', () => {
+      const leftItem: User = { id: '1', name: 'John', lastName: 'Doe' };
+      const rightItem: User = { id: '1', name: 'John', lastName: 'Doe' };
+      expect(areItemsEqual(leftItem, rightItem, undefined)).toBe(true);
+    });
+  });
+
+  it('getItemIndex()', () => {
+    const users: User[] = [
+      { id: '1', name: 'John', lastName: 'Doe' },
+      { id: '2', name: 'Ana', lastName: 'Wick' },
+      { id: '3', name: 'Xuxu', lastName: 'Bar' },
+    ];
+    expect(getItemIndex(users, { id: '2' }, 'id')).toBe(1);
+  });
+});


### PR DESCRIPTION
### `Add 'itemsKey' prop and items-expanded v-model`

- The 'itemsKey' prop was introduced to improve row items tracking,
The previous implementation was using JSON.stringify, it can introduce
issues with non-static data.
- The 'items-expanded' v-model was introduced to handle the expanded
rows, we can track what are the expanded rows, expand all rows or
specific rows.

- [x] Feature  

https://github.com/HC200ok/vue3-easy-data-table/issues/132

Example:
You can expand all the items:
` <easy-data-table
    :headers="headers"
    :items="items"
    :items-expanded="items"
    items-key="id"
  />`

You can expand a specific item
` <easy-data-table
    :headers="headers"
    :items="items"
    :items-expanded="[items[0]]"
    items-key="id"
  />`

You can detect when items were expanded:

`function onItemsExpanded(expandedItems: Item[]) {
    console.log(expandedItems)
}
 `


`<easy-data-table
    :headers="headers"
    :items="items"
    items-key="id"
   @update:items-expanded="onItemsExpanded"
  />`

**Notice** the **items-key** prop, it is very useful to track the expanded rows, even if you refresh the items of the table.


