### PR TITLE
feat: add optional `prevent-context-menu-row` prop defaulting to `true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.43",
+  "version": "1.5.44",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -133,7 +133,7 @@
                 clickRowToExpand && updateExpandingItemIndexList(index + prevPageEndIndex, item, $event);
               }"
               @dblclick="($event) => {clickRow(item, 'double', $event)}"
-              @contextmenu.prevent="($event) => {emits('contextmenuRow', item, $event)}"
+              @contextmenu="($event) => {contextMenuRow(item, $event)}"
             >
               <td
                 v-for="(column, i) in headerColumns"
@@ -369,6 +369,7 @@ const {
   themeColor,
   rowsOfPageSeparatorMessage,
   showIndexSymbol,
+  preventContextMenuRow
 } = toRefs(props);
 
 // style related computed variables
@@ -553,6 +554,11 @@ const {
   showIndex,
   emits,
 );
+
+const contextMenuRow = (item: Item, $event: MouseEvent) => {
+  if (preventContextMenuRow.value) $event.preventDefault();
+  emits('contextmenuRow', item, $event);
+}
 
 // template style generation function
 const getColStyle = (header: HeaderForRender): string | undefined => {

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -194,5 +194,9 @@ export default {
   showIndexSymbol: {
     type: String,
     default: '#',
+  },
+  preventContextMenuRow: {
+    type: Boolean,
+    default: true
   }
 };


### PR DESCRIPTION
This implements the feature suggested in https://github.com/HC200ok/vue3-easy-data-table/issues/289

### `Type`

> What types of changes does your code introduce?

> Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature 


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
