### PR TITLE
Optional hover menu and mouseover events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-easy-data-table",
-  "version": "1.5.44",
+  "version": "1.5.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-easy-data-table",
-      "version": "1.5.44",
+      "version": "1.5.47",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.2.45"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.47",
+  "version": "1.5.48",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vue3-easy-data-table",
+  "name": "wl-vue3-easy-data-table",
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
@@ -10,13 +10,7 @@
     "dist",
     "types"
   ],
-  "keywords": [
-    "vue3",
-    "data-table-component",
-    "data-table",
-    "vue3-component",
-    "vue-component"
-  ],
+  "keywords": [],
   "homepage": "https://github.com/HC200ok/vue3-easy-data-table",
   "main": "./dist/vue3-easy-data-table.umd.js",
   "module": "./dist/vue3-easy-data-table.es.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.56",
+  "version": "1.5.48",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "HC200ok",
   "description": "A customizable and easy-to-use data table component made with Vue.js 3.x.",
   "private": false,
-  "version": "1.5.48",
+  "version": "1.5.56",
   "types": "./types/main.d.ts",
   "license": "MIT",
   "files": [

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -48,7 +48,7 @@
               :style="getFixedDistance(header.value)"
               @click.stop="(header.sortable && header.sortType) ? updateSortField(header.value, header.sortType) : null"
             >
-              <MultipleSelectCheckBox
+            <MultipleSelectCheckBox
                 v-if="header.text === 'checkbox'"
                 :key="multipleSelectStatus"
                 :status="multipleSelectStatus"
@@ -142,6 +142,7 @@
             >
               <td
                 v-for="(column, i) in headerColumns"
+                :id="`checkBoxTD_${index}`"
                 :key="i"
                 :style="getFixedDistance(column, 'td')"
                 :class="[{
@@ -209,7 +210,7 @@
               <td
                 :colspan="headersForRender.length"
               >
-              <div>
+              <div :style="getHoverStyle(index)">
                 <slot
                   name="hover"
                   v-bind="item"
@@ -609,11 +610,29 @@ const getColStyle = (header: HeaderForRender): string | undefined => {
   return undefined;
 };
 
-const getFixedDistance = (column: string, type: 'td' | 'th' = 'th') => {
+const getHoverStyle = (index:number): string | undefined => {
+
+  let checkBoxTDId = `checkBoxTD_${index}`;
+  let checkboxTD = document.getElementById(checkBoxTDId);
+  if(checkboxTD)
+  {
+    const width = checkboxTD.clientWidth + 2;
+    return `width: calc(100% - ${width}px); min-width: calc(100% - ${width}px); margin-left:  ${width}px`;
+  }
+  
+  return undefined;
+};
+
+const getFixedDistance = (column: string, type: 'td' | 'th' = 'th', setMarginLeft: boolean = false) => {
   if (!fixedHeaders.value.length) return undefined;
   const columInfo = fixedColumnsInfos.value.find((info) => info.value === column);
   if (columInfo) {
-    return `left: ${columInfo.distance}px;z-index: ${type === 'th' ? 3 : 1};position: sticky;`;
+    if(!setMarginLeft)
+    {
+      return `left: ${columInfo.distance}px;z-index: ${type === 'th' ? 3 : 1};position: sticky;`;
+    } else {
+      return `margin-left: ${columInfo.distance}px;`;
+    }
   }
   return undefined;
 };
@@ -670,7 +689,7 @@ defineExpose({
   updatePage,
   rowsPerPageOptions: rowsItemsComputed,
   rowsPerPageActiveOption: rowsPerPageRef,
-  updateRowsPerPageActiveOption: updateRowsPerPage,
+  updateRowsPerPageActiveOption: updateRowsPerPage
 });
 
 </script>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -204,12 +204,12 @@
             </tr>
             <tr
               v-if="ifHasHoverSlot && hoverRowIndex === index + prevPageEndIndex"
-              :class="['hover-row']"
+              :class="['hover-row', {'even-row': (index + 1) % 2 === 0}]"
             >
               <td
                 :colspan="headersForRender.length"
               >
-              <div :class="[{'even-row': (index + 1) % 2 === 0}]">
+              <div>
                 <slot
                   name="hover"
                   v-bind="item"

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -105,6 +105,7 @@
           v-else-if="headerColumns.length"
           class="vue3-easy-data-table__body"
           :class="{'row-alternation': alternating}"
+          @mouseleave="hoverRowToShowElement && clearHoverRowIndex()"
         >
           <slot
             name="body-prepend"
@@ -208,7 +209,7 @@
               <td
                 :colspan="headersForRender.length"
               >
-              <div :class="[{'even-row': (index + 1) % 2 === 0}, typeof bodyExpandRowClassName === 'string' ? bodyExpandRowClassName : bodyExpandRowClassName(item, index + 1)]">
+              <div :class="[{'even-row': (index + 1) % 2 === 0}]">
                 <slot
                   name="hover"
                   v-bind="item"
@@ -217,16 +218,6 @@
                 
               </td>
             </tr>
-            <!-- <div
-              v-if="ifHasHoverSlot && hoverRowIndex === index + prevPageEndIndex"
-              :class="[{'even-row': (index + 1) % 2 === 0},
-                       typeof bodyExpandRowClassName === 'string' ? bodyExpandRowClassName : bodyExpandRowClassName(item, index + 1)]"
-            >
-                <slot
-                  name="hover"
-                  v-bind="item"
-                />
-            </div> -->
           </template>
           <slot
             name="body-append"

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -616,7 +616,6 @@ const getHoverStyle = (index:number): string | undefined => {
   let checkboxTD = document.getElementById(checkBoxTDId);
   if(checkboxTD)
   {
-    console.log(checkboxTD)
     const width = checkboxTD.clientWidth + 2;
     const height = checkboxTD.clientHeight - 1;
     return `width: calc(100% - ${width}px); min-width: calc(100% - ${width}px); margin-left:  ${width}px; top: ${-height}px; height: ${height}px; min-height: ${height}px`;

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -203,19 +203,30 @@
             </tr>
             <tr
               v-if="ifHasHoverSlot && hoverRowIndex === index + prevPageEndIndex"
-              :class="[{'even-row': (index + 1) % 2 === 0},
-                       typeof bodyExpandRowClassName === 'string' ? bodyExpandRowClassName : bodyExpandRowClassName(item, index + 1)]"
+              :class="['hover-row']"
             >
               <td
                 :colspan="headersForRender.length"
-                class="expand"
               >
+              <div :class="[{'even-row': (index + 1) % 2 === 0}, typeof bodyExpandRowClassName === 'string' ? bodyExpandRowClassName : bodyExpandRowClassName(item, index + 1)]">
                 <slot
                   name="hover"
                   v-bind="item"
                 />
+              </div>
+                
               </td>
             </tr>
+            <!-- <div
+              v-if="ifHasHoverSlot && hoverRowIndex === index + prevPageEndIndex"
+              :class="[{'even-row': (index + 1) % 2 === 0},
+                       typeof bodyExpandRowClassName === 'string' ? bodyExpandRowClassName : bodyExpandRowClassName(item, index + 1)]"
+            >
+                <slot
+                  name="hover"
+                  v-bind="item"
+                />
+            </div> -->
           </template>
           <slot
             name="body-append"
@@ -735,4 +746,5 @@ defineExpose({
 .vue3-easy-data-table__main.fixed-height {
   height: v-bind(tableHeightPx);
 }
+
 </style>

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -616,8 +616,10 @@ const getHoverStyle = (index:number): string | undefined => {
   let checkboxTD = document.getElementById(checkBoxTDId);
   if(checkboxTD)
   {
+    console.log(checkboxTD)
     const width = checkboxTD.clientWidth + 2;
-    return `width: calc(100% - ${width}px); min-width: calc(100% - ${width}px); margin-left:  ${width}px`;
+    const height = checkboxTD.clientHeight - 1;
+    return `width: calc(100% - ${width}px); min-width: calc(100% - ${width}px); margin-left:  ${width}px; top: ${-height}px; height: ${height}px; min-height: ${height}px`;
   }
   
   return undefined;

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -210,7 +210,7 @@
               <td
                 :colspan="headersForRender.length"
               >
-              <div :style="getHoverStyle(index)">
+              <div :style="getHoverStyle(index)" :class="{'even-row': alternating && (index + 1) % 2 === 0}">
                 <slot
                   name="hover"
                   v-bind="item"
@@ -610,18 +610,32 @@ const getColStyle = (header: HeaderForRender): string | undefined => {
   return undefined;
 };
 
+// const getHoverStyle = (index:number): string | undefined => {
+
+//   let checkBoxTDId = `checkBoxTD_${index}`;
+//   let checkboxTD = document.getElementById(checkBoxTDId);
+//   if(checkboxTD)
+//   {
+//     const width = checkboxTD.clientWidth + 2;
+//     const height = checkboxTD.clientHeight - 1;
+//     return `width: calc(100% - ${width}px); min-width: calc(100% - ${width}px); margin-left:  ${width}px; top: ${-height}px; height: ${height}px; min-height: ${height}px`;
+//   }
+  
+//   return undefined;
+// };
+
 const getHoverStyle = (index:number): string | undefined => {
 
-  let checkBoxTDId = `checkBoxTD_${index}`;
-  let checkboxTD = document.getElementById(checkBoxTDId);
-  if(checkboxTD)
-  {
-    const width = checkboxTD.clientWidth + 2;
-    const height = checkboxTD.clientHeight - 1;
-    return `width: calc(100% - ${width}px); min-width: calc(100% - ${width}px); margin-left:  ${width}px; top: ${-height}px; height: ${height}px; min-height: ${height}px`;
-  }
-  
-  return undefined;
+let checkBoxTDId = `checkBoxTD_${index}`;
+let checkboxTD = document.getElementById(checkBoxTDId);
+if(checkboxTD)
+{
+  const width = checkboxTD.clientWidth + 2;
+  const height = checkboxTD.clientHeight;
+return `margin-left: ${width}px; top: ${-height}px; height: ${height - 2}px; min-height: ${height - 2}px`;
+}
+
+return undefined;
 };
 
 const getFixedDistance = (column: string, type: 'td' | 'th' = 'th', setMarginLeft: boolean = false) => {

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -132,6 +132,9 @@
                 clickRow(item, 'single', $event);
                 clickRowToExpand && updateExpandingItemIndexList(index + prevPageEndIndex, item, $event);
               }"
+              @mouseover="($event) => {
+                hoverRow(item, $event)
+              }"
               @dblclick="($event) => {clickRow(item, 'double', $event)}"
               @contextmenu="($event) => {contextMenuRow(item, $event)}"
             >
@@ -318,10 +321,10 @@ import useTotalItems from '../hooks/useTotalItems';
 
 import type { Header, Item } from '../types/main';
 import type { HeaderForRender } from '../types/internal';
-
 // eslint-disable-next-line import/extensions
 import { generateColumnContent } from '../utils';
 import propsWithDefault from '../propsWithDefault';
+import useHoverRow from '../hooks/useHoverRow';
 
 const props = defineProps({
   ...propsWithDefault,
@@ -401,6 +404,7 @@ onMounted(() => {
 
 const emits = defineEmits([
   'clickRow',
+  'hoverRow',
   'contextmenuRow',
   'selectRow',
   'deselectRow',
@@ -551,6 +555,13 @@ const {
 } = useClickRow(
   clickEventType,
   isMultipleSelectable,
+  showIndex,
+  emits,
+);
+
+const {
+  hoverRow,
+} = useHoverRow(
   showIndex,
   emits,
 );

--- a/src/hooks/useHoverRow.ts
+++ b/src/hooks/useHoverRow.ts
@@ -1,0 +1,20 @@
+import { Ref, ComputedRef } from 'vue';
+import type { Item } from '../types/main';
+import type { EmitsEventName, ClickEventType } from '../types/internal';
+
+export default function useHoverRow(
+  showIndex: Ref<boolean>,
+  emits: (event: EmitsEventName, ...args: any[]) => void,
+) {
+  const hoverRow = (item: Item, $event: Event) => {
+    const hoverRowArgument = { ...item };
+      const { index } = item;
+      delete hoverRowArgument.index;
+      hoverRowArgument.indexInCurrentPage = index;
+    emits('hoverRow', hoverRowArgument, $event);
+  };
+
+  return {
+    hoverRow,
+  };
+}

--- a/src/hooks/useHoverRowElement.ts
+++ b/src/hooks/useHoverRowElement.ts
@@ -1,0 +1,32 @@
+import { ref, Ref, ComputedRef } from 'vue';
+import type { Item } from '../types/main';
+import type { EmitsEventName } from '../types/internal';
+
+export default function useHoverRowElement(
+  items: Ref<Item[]>,
+  prevPageEndIndex: ComputedRef<number>,
+  emits: (event: EmitsEventName, ...args: any[]) => void,
+) {
+  const hoverRowIndex = ref<number>();
+
+  const updateHoverRowIndex = (index: number, hoverItem: Item, event: Event) => {
+    event.stopPropagation();
+    if (index !== -1) {
+      hoverRowIndex.value = index;
+    } else {
+      const currentPageExpandIndex = items.value.findIndex((item) => JSON.stringify(item) === JSON.stringify(hoverItem));
+      emits('showHoverElement', prevPageEndIndex.value + currentPageExpandIndex, hoverItem);
+      hoverRowIndex.value = prevPageEndIndex.value + currentPageExpandIndex;
+    }
+  };
+
+  const clearHoverRowIndex = () => {
+    hoverRowIndex.value = undefined;
+  };
+
+  return {
+    hoverRowIndex,
+    updateHoverRowIndex,
+    clearHoverRowIndex,
+  };
+}

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -71,8 +71,8 @@
       </template>
 
       <template #hover="item">
-        <div style="padding: 15px">
-          {{ item.name }} is ze coolest
+        <div style="padding: 10px 0px 0px 15px;">
+          This might show menu options or something for {{ item.name }}...
         </div>
       </template>
 

--- a/src/modes/Client.vue
+++ b/src/modes/Client.vue
@@ -12,7 +12,7 @@
     <DataTable
       table-node-id="my-table"
       v-model:items-selected="itemsSelected"
-      click-row-to-expand
+      hover-row-to-show-element
       ref="dataTable"
       alternating
       border-cell
@@ -67,6 +67,12 @@
       <template #expand="item">
         <div style="padding: 15px">
           {{ item.name }} won championships
+        </div>
+      </template>
+
+      <template #hover="item">
+        <div style="padding: 15px">
+          {{ item.name }} is ze coolest
         </div>
       </template>
 

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -187,6 +187,10 @@ export default {
     type: Boolean,
     default: false,
   },
+  hoverRowToShowElement: {
+    type: Boolean,
+    default: false,
+  },
   tableNodeId: {
     type: String,
     default: '',

--- a/src/scss/vue3-easy-data-table.scss
+++ b/src/scss/vue3-easy-data-table.scss
@@ -261,7 +261,7 @@ table {
 // hover row feature related
 .hover-row {
   height: 0 !important;
-  visibility: visible;
+  padding: 0;
 
   td {
     height: 0;
@@ -274,8 +274,6 @@ table {
       margin-top: calc(var(--easy-table-body-row-height) * -1);
       height: var(--easy-table-body-row-height);
       background-color: inherit;
-      left: 0;
-      z-index: 10;
     }
   }
 }

--- a/src/scss/vue3-easy-data-table.scss
+++ b/src/scss/vue3-easy-data-table.scss
@@ -266,6 +266,7 @@ table {
   td {
     height: 0;
     padding: 0;
+    margin: 0;
     position: relative;
 
     div {
@@ -274,7 +275,6 @@ table {
       height: var(--easy-table-body-row-height);
       background-color: inherit;
       left: 0;
-      width: 100%;
       z-index: 10;
     }
   }

--- a/src/scss/vue3-easy-data-table.scss
+++ b/src/scss/vue3-easy-data-table.scss
@@ -268,10 +268,29 @@ table {
     padding: 0;
     margin: 0;
     position: relative;
+    border: none;
 
     div {
       position: absolute;
+      right: 0px;
+      z-index: 10;
       background-color: inherit;
+
+      &::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: -80px;
+        bottom: 0;
+        width: 90px;
+        background: linear-gradient(to right, transparent, var(--easy-table-body-row-background-color))
+      }
+    }
+
+    div.even-row {
+      &::before {
+        background: linear-gradient(to right, transparent, var(--easy-table-body-even-row-background-color))
+      }
     }
   }
 }

--- a/src/scss/vue3-easy-data-table.scss
+++ b/src/scss/vue3-easy-data-table.scss
@@ -271,8 +271,6 @@ table {
 
     div {
       position: absolute;
-      margin-top: calc(var(--easy-table-body-row-height) * -1);
-      height: var(--easy-table-body-row-height);
       background-color: inherit;
     }
   }

--- a/src/scss/vue3-easy-data-table.scss
+++ b/src/scss/vue3-easy-data-table.scss
@@ -258,6 +258,28 @@ table {
   cursor: pointer;
 }
 
+// hover row feature related
+.hover-row {
+  height: 0 !important;
+  visibility: visible;
+
+  td {
+    height: 0;
+    padding: 0;
+    position: relative;
+
+    div {
+      position: absolute;
+      margin-top: calc(var(--easy-table-body-row-height) * -1);
+      height: var(--easy-table-body-row-height);
+      background-color: inherit;
+      left: 0;
+      width: 100%;
+      z-index: 10;
+    }
+  }
+}
+
 .vue3-easy-data-table__footer {
   background-color: var(--easy-table-footer-background-color);
   color: var(--easy-table-footer-font-color);

--- a/src/types/internal.d.ts
+++ b/src/types/internal.d.ts
@@ -26,4 +26,4 @@ export type ClickEventType = 'single' | 'double'
 export type MultipleSelectStatus = 'allSelected' | 'noneSelected' | 'partSelected'
 
 // eslint-disable-next-line max-len
-export type EmitsEventName = 'clickRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll'
+export type EmitsEventName = 'clickRow' | 'hoverRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll'

--- a/src/types/internal.d.ts
+++ b/src/types/internal.d.ts
@@ -26,4 +26,4 @@ export type ClickEventType = 'single' | 'double'
 export type MultipleSelectStatus = 'allSelected' | 'noneSelected' | 'partSelected'
 
 // eslint-disable-next-line max-len
-export type EmitsEventName = 'clickRow' | 'hoverRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll'
+export type EmitsEventName = 'clickRow' | 'hoverRow' | 'selectRow' | 'deselectRow' | 'expandRow' | 'showHoverElement' | 'updateSort' | 'update:itemsSelected' | 'update:serverOptions' | 'updateFilter' | 'updatePageItems' | 'updateTotalItems' | 'selectAll'


### PR DESCRIPTION
### `Type`

> It lets the user optionally create a slot that appears on hover over a row. This is super useful for user experiences where you'd like a menu of options to appear on the row if you hover over it. Very common case, as google and many others use it all the time. It also gives the user the option to listen to a "hover" event if they'd like.

We need this for our product! Thank you for this table, it rocks.

> Put an `x` in the boxes that apply_

- [ ] Fix
- [x] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary

DEMO

https://github.com/HC200ok/vue3-easy-data-table/assets/38018663/2d02eab0-8cab-4b19-a827-7daecc8897ac

USAGE:
1. just add `hover-row-to-show-element` to your `DataTable`
2. make use of the slot like so:
```
<template #hover="item">
  <div style="padding: 10px 0px 0px 15px;">
    This might show menu options or something for {{ item.name }}...
  </div>
</template>
```

