### PR TITLE
feat(sort): add props for custom sorting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-easy-data-table",
-  "version": "1.5.44",
+  "version": "1.5.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-easy-data-table",
-      "version": "1.5.44",
+      "version": "1.5.47",
       "license": "MIT",
       "dependencies": {
         "vue": "^3.2.45"

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -369,7 +369,9 @@ const {
   themeColor,
   rowsOfPageSeparatorMessage,
   showIndexSymbol,
-  preventContextMenuRow
+  preventContextMenuRow,
+  sortFunction,
+  multiSortFunction,
 } = toRefs(props);
 
 // style related computed variables
@@ -484,6 +486,8 @@ const {
   searchValue,
   serverItemsLength,
   multiSort,
+  sortFunction,
+  multiSortFunction,
   emits,
 );
 

--- a/src/hooks/useTotalItems.ts
+++ b/src/hooks/useTotalItems.ts
@@ -113,7 +113,6 @@ export default function useTotalItems(
     if (clientSortOptions.value === null) return itemsFiltering.value;
     const { sortBy, sortDesc } = clientSortOptions.value;
     const itemsFilteringSorted = [...itemsFiltering.value];
-    console.log(multiSort.value)
 
     // multi sort
     if (multiSort.value && Array.isArray(sortBy) && Array.isArray(sortDesc)) {

--- a/src/propsWithDefault.ts
+++ b/src/propsWithDefault.ts
@@ -2,9 +2,9 @@ import { PropType } from 'vue';
 import type {
   SortType, Item, ServerOptions, FilterOption,
   HeaderItemClassNameFunction, BodyItemClassNameFunction, BodyRowClassNameFunction,
-  TextDirection,
+  TextDirection, MultiSortFunction, SortFunction
 } from './types/main';
-import type { ClickEventType } from './types/internal';
+import type {ClickEventType} from './types/internal';
 
 export default {
   alternating: {
@@ -126,6 +126,14 @@ export default {
   multiSort: {
     type: Boolean,
     default: false,
+  },
+  sortFunction: {
+    type: Function as PropType<SortFunction> | null,
+    default: null
+  },
+  multiSortFunction: {
+    type: Function as PropType<MultiSortFunction> | null,
+    default: null
   },
   tableMinHeight: {
     type: Number,

--- a/src/types/main.d.ts
+++ b/src/types/main.d.ts
@@ -1,3 +1,5 @@
+import {getItemValue as getItemValueFn} from "../utils";
+
 export type SortType = 'asc' | 'desc'
 
 export type FilterComparison = '=' | '!=' | '>' | '>=' | '<' | '<=' | 'between' | 'in';
@@ -50,6 +52,9 @@ export type UpdateSortArgument = {
   sortType: SortType | null
   sortBy: string
 }
+
+export type SortFunction = (a: Item, b: Item, sortBy: string, sortDesc: boolean, getItemValue: typeof getItemValueFn, defaultSortFunction: (a: Item, b: Item) => number) => number;
+export type MultiSortFunction = (sortByArr: string[], sortDescArr: boolean[], itemsToSort: Item[], index: number) => Item[];
 
 export type HeaderItemClassNameFunction = (header: Header, columnNumber: number) => string
 export type BodyRowClassNameFunction = (item: Item, rowNumber: number) => string


### PR DESCRIPTION
This is a feature proposal that adresses #177 

The following new props have been added:
* `sort-function`
* `multi-sort-function`

## `sort-function`
takes the following arguments:
* a: Item
* b: Item
* sortBy: string
* sortDesc: boolean
* getItemValue: typeof getItemValueFn
* defaultSortFunction: (a: Item, b: Item) => number

it should return a number, if a nullish (`undefined` and `null`) is returned, the default sort function will automatically be applied.

## `multi-sort-function`
takes the following arguments:
* sortByArr: string[]
* sortDescArr: boolean[]
* itemsToSort: Item[]
* index: number

it should return an Item[] (Array of Item-Objects). There is no "fallback to default if undefined returned" as for `sort-function` to allow more controll over the sorting.