### PR TITLE
Fix small typo in CSS variable name

### DIFF
--- a/src/scss/vue3-easy-data-table.scss
+++ b/src/scss/vue3-easy-data-table.scss
@@ -232,7 +232,7 @@ table {
   position: relative;
   .expand-icon {
     border: solid;
-    border-color: var(easy-table-body-row-font-color);
+    border-color: var(--easy-table-body-row-font-color);
 
     border-width: 0 2px 2px 0;
     display: inline-block;


### PR DESCRIPTION
As explained in issue #367 this is a tiny commit that just adds the missing `--` prefix for a CSS variable.

### `Type`

> What types of changes does your code introduce?
Fix a tiny typo in a CSS variable name, doesn't need a custom test imho.

> Put an `x` in the boxes that apply_

- [x] Fix
- [ ] Feature


### `Checklist`

> Put an `x` in the boxes that apply._

- [x] Title as described
- [ ] Add unit test by vitest if necessary
